### PR TITLE
v3.22 documentation

### DIFF
--- a/docs/commands.mdx
+++ b/docs/commands.mdx
@@ -118,7 +118,7 @@ The queue command displays information about the guild's queue (`info`) or displ
 | `info` | View information about the guild's suggestions' queue | `/queue info` | **true** |
 | `view` | View the guild's suggestions' queue                   | `/queue view` | **true** |
 
-Read more about how you can quality control suggestions in your server via the [queue](queue.md) page.
+Read more about how you can quality control suggestions in your server via the [queue](queue) page.
 
 ### Ping Command
 

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -3,6 +3,8 @@ sidebar_position: 3
 title: Configuration
 description: Learn how to configure various aspects of the Suggestions bot.
 ---
+import QueuedSuggestionEmbedMessage
+  from '@site/src/components/Messages/QueuedSuggestionEmbedMessage';
 import ServerConfiguration from '@site/src/components/Embeds/ServerConfiguration';
 import SuggestionEmbedMessage from '@site/src/components/Messages/SuggestionEmbedMessage';
 import SuggestionThreadMessage from '@site/src/components/Messages/SuggestionThreadMessage';
@@ -81,21 +83,57 @@ When enabled, this configuration allows a suggestion to remain in the channel wh
 
 ## Anonymous Suggestions
 
-Usage `/config get config:Anonymous suggestions` (to view) or `/config anonymous <enable|disable>`
+Usage `/config get config:Anonymous suggestions` (to view) or `/config anonymous <enable|disable>` (to set)
 
 When enabled, this configuration allows users to optionally submit a suggestion as anonymous, omitting any of their profile infomation from the suggestion. Read more about this feature [here](anonymous-suggestions.mdx).
 
 ## Auto Archive Threads
 When enabled, this configuration allows the bot to automatically archive suggestions threads when resolved (approved or rejected).
 
-Usage `/config get config:Auto archive threads` (to view) or `/config auto_archive_threads <enable|disable>`
+Usage `/config get config:Auto archive threads` (to view) or `/config auto_archive_threads <enable|disable>` (to set)
 
 ## Images In Suggestions
+
 By default, users can attach images to new suggestions. If disabled, submitters will receive a warning that they cannot add images as a Discord attachment.
 
-Usage `/config get config:Images in suggestions` (to view) or `/config images_in_suggestions <enable|disable>`
+Usage `/config get config:Images in suggestions` (to view) or `/config images_in_suggestions <enable|disable>` (to set)
 
 ## Anonymous Resolutions
+
 By default, the suggestion displays the staff member who resolved it when approved or rejected. If disabled, "Anonymous" will replace their name. Read more about this feature [here](anonymous-suggestions.mdx#anonymous-resolutions).
 
-Usage `/config get config:Anonymous resolutions` (to view) or `/config anonymous_resolutions <enable|disable>`
+Usage `/config get config:Anonymous resolutions` (to view) or `/config anonymous_resolutions <enable|disable>` (to set)
+
+## Suggestion Queue
+
+When enabled, all new suggestions are sent to either a virtual or channel queue for approval. Once a suggestion is approved, it is sent to the set suggestions channel for the public to vote on.
+
+Usage `/config get config:Suggestions queue` (to view) or `/config suggestion_queue <enable|disable>` (to set)
+
+Read more about the suggestion queue [here](queue).
+
+## Queue Channel
+
+You can view or set the channel where queued suggestions will be posted. You can choose from a list of text channels in your server. To use this channel, you must enable the queue channel.
+
+Usage: `/config get config:Queue channel` (to view) or `/config queue_channel <channel>` (to set)
+
+<QueuedSuggestionEmbedMessage />
+
+Read more about the suggestion queue [here](queue#channel-queue).
+
+## Queue Log Channel
+
+You can view, set, or remove the channel where rejected suggestions in the queue are sent. You can choose from a list of text channels in your server. This channel can be unset by omitting the `channel:<channel>` option.
+
+Usage `/config get config:Queue rejection channel` (to view) or `/config queue_log_channel [channel:<channel>]` (to set)
+
+Read more about the suggestion queue [here](queue#channel-queue).
+
+## Use Channel Queue
+
+This configuration will post queued suggestions to the set suggestions queue channel when enabled. For this to work, you must have a queue channel set with proper permissions. When disabled, you can access a virtual queue with the `/queue view` command.
+
+Usage: `/config get config:Using channel queue` (to view) or `/config use_channel_queue <enable|disable>` (to set)
+
+Read more about the suggestion queue [here](queue#channel-queue).

--- a/docs/errors.mdx
+++ b/docs/errors.mdx
@@ -32,7 +32,9 @@ import { DiscordInlineCode } from '@skyra/discord-components-react';
 | 20   | QUEUE_IMBALANCE                                  | [click](#queue-imbalance)                                 |
 | 21   | MISSING_QUEUE_CHANNEL                            | [click](#missing-queue-channel)                           |
 | 22   | BLOCKLISTED_USER                                 | [click](#blocklisted-user)                                |
-
+| 23   | MISSING_QUEUE_LOG_CHANNEL                        | [click](#missing-queue-log-channel)                       |
+| 24   | MISSING_PERMISSIONS_IN_QUEUE_CHANNEL             | [click](#missing-permissions-in-queue-channel)            |
+| 25   | INVALID_FILE_TYPE                                | [click](#invalid-file-type)                               |
 ## Error Information
 
 ### Suggestion Message Deleted
@@ -273,3 +275,45 @@ but you have been blocked by an administrator within the guild.
         </>
     }
     code={22} />
+
+### Missing Queue Log Channel
+
+This error is thrown when there is no configured channel to log queued suggesitons. This happens when suggestion queueing is enabled and a new suggestion or rejected suggestion is trying to be sent to the queue log channel.
+<ErrorEmbed
+  title="Missing Queue Logs Channel"
+  description={
+    <>
+      This command requires a queue log channel to use.
+      <br/><br/>
+      Please contact an administrator and ask them to set one up using the following command.
+      <br/><br/>
+      <DiscordInlineCode>/config queue_channel</DiscordInlineCode>
+    </>
+  }
+  code={23} />
+
+### Missing Permissions In Queue Channel
+
+This error is thrown when trying to send a new queued suggestion to the queue channel, but the bot lacks the required permissions in the channel.
+<ErrorEmbed
+  title="Missing permissions within queue logs channel"
+  description={
+    <>
+      The bot does not have the required permissions in your queue channel. Please contact an administrator and ask them to fix this.
+    </>
+  }
+  code={24} />
+
+### Invalid File Type
+
+This error is thrown when uploading an invalid image file type on a suggestion.
+<ErrorEmbed
+  title="Invalid file type"
+  description={
+    <>
+      The file you attempted to upload is not an accepted type.
+      <br/><br/>
+      If you believe this is an error please reach out to us via our support discord.
+    </>
+  }
+  code={25} />

--- a/docs/queue.mdx
+++ b/docs/queue.mdx
@@ -3,6 +3,8 @@ sidebar_position: 8
 title: Suggestion Queue
 description: Learn how to utilize the suggestion queue to manage the flow of suggestions to the public.
 ---
+import SuggestionSlashReply
+  from '../src/components/Messages/SuggestionSlashReply';import QueuedSuggestionEmbedMessage from '@site/src/components/Messages/QueuedSuggestionEmbedMessage';
 import SuggestionEmbedMessage from '@site/src/components/Messages/SuggestionEmbedMessage';
 import QueueInfo from '@site/src/components/Embeds/QueueCommand/QueueInfo.tsx'
 import QueueView from '@site/src/components/Embeds/QueueCommand/QueueView.tsx'
@@ -16,15 +18,36 @@ The suggestion queue is one of our most powerful features on the bot. By putting
 Improve the quality of your community by moderating its suggestions. Learn more about it below.
 
 ## Purpose
-This feature will send all suggestions made via `/suggest` to a queue, after which a moderator for your server can approve or reject suggestions before the public views them in your suggestions channel for voting.
+This feature will send all suggestions made via `/suggest` to a queue, after which a moderator for your server can approve or reject suggestions before the public views them in your suggestions channel for voting. The queue can managed and interacted with virtually or through a text channel in your server. Additionally, you may set a logs channel for rejected suggestions from the queue to be accounted for.
 
 ## Usage
-To enable the suggestions queue, run `/config suggestion_queue enable`.  You can then use the following commands to manage your queue:
+To enable the suggestions queue, run `/config suggestion_queue enable`.  From here, you may manage the queue in one of two ways:
+- [Virtual Queue](#virtual-queue)
+- [Channel Queue](#channel-queue)
+
+<SuggestionSlashReply command="/suggest" message="Your suggestion has been sent to the queue for processing." />
+
+### Anonymous Suggestions
+If enabled in your guild, when users submit suggestions anonymously, their user information remains anonymous during the queue process for continued privacy practices in your community.
+
+<QueuedSuggestionEmbedMessage embed={{ anonymousAuthor: true }} />
+
+## Queue Logs Channel
+Whether you choose to set up a virtual or channel queue, you can log rejected suggestions to a set channel. The channel can be unset using the same command, disabling the logging of rejected suggestions.
+- [`/config queue_logs_channel channel:<channel>`](#channel-queue) (to set the queue logs channel)
+- [`/config queue_logs_channel`](#channel-queue) (to unset the queue logs channel)
+
+## Virtual Queue
+When using the virtual queue, you'll be able to interact with the queue using the following commands:
 
 - [`/queue info`](#queue-info)
 - [`/queue view`](#queue-view)
 
-## Queue Info
+In this mode, queued suggestions do not have a channel presence. The only time suggestions are sent to a channel is when they are approved or rejected.
+
+### Commands
+
+#### Queue Info
 The [`/queue info`](commands#queue-command) command will display the status of your server's suggestions queue.
 
 You can check if new suggestions go to the queue and see how many are there.
@@ -32,7 +55,7 @@ You can check if new suggestions go to the queue and see how many are there.
 
 The above example displays that the server has the suggestions queue enabled and that there's currently `1` suggestion in the queue.
 
-## Queue View
+#### Queue View
 The [`/queue view`](commands#queue-command) command will display active suggestions in the queue. You can cycle through the queue and approve/reject suggestions.
 <QueueView />
 
@@ -74,3 +97,21 @@ You'll receive this message in the channel when rejecting the selected queued su
   embed={<QueueRejection />}
 />
 The bot will also attempt to DM the user this message.
+
+#### Rejection Logging
+You may optionally send rejected suggestions in the suggestion queue to a separate logs channel for moderation/auditing purposes. The commands are in the [Queue Logs Channel](#queue-logs-channel) section.
+
+As you can see above, if the suggestion wasn't submitted anonymously, you'll notice the content and the submitter's information.
+
+## Channel Queue
+When the physical queue is enabled, it works similarly to the [`/queue view`](#queue-view) command. However, each queued suggestion is posted similarly to a suggestion submitted to the virtual queue, with the difference being the buttons assigned.
+
+<QueuedSuggestionEmbedMessage />
+
+Each button has a different action, which functions similarly to the virtual queue.
+
+### Approving a suggestion
+Approving a suggestion in the channel queue is virtually (no pun intended) the same as approving it from the virtual queue.
+
+### Rejecting a suggestion
+Rejecting a suggestion in the channel queue is the same as rejecting a suggestion from the virtual queue. If you have the log channel enabled for rejected suggestions in the queue, rejected suggestions will be logged in the queue logs channel.

--- a/modules/discordComponents.js
+++ b/modules/discordComponents.js
@@ -5,7 +5,7 @@ if (ExecutionEnvironment.canUseDOM) {
     profiles: {
       suggestions: {
         author: 'Suggestions',
-        avatar: 'https://cdn.discordapp.com/avatars/474051954998509571/4be94ad8814f59502586974ee31efd21.png?size=4096',
+        avatar: 'https://cdn.discordapp.com/avatars/474051954998509571/a_9284248445d77d12be8256ebcc88948e.gif?size=1024',
         bot: true,
         verified: true,
         roleColor: '#ffd663',

--- a/src/components/Embeds/QueuedSuggestion.tsx
+++ b/src/components/Embeds/QueuedSuggestion.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import SuggestionEmbed from '@site/src/components/Embeds/SuggestionEmbed';
+import { EmbedColor } from '@site/src/constants';
+import { DiscordBold } from '@skyra/discord-components-react';
+
+export default function QueuedSuggestion({
+  anonymousAuthor,
+  footer,
+}: {
+  anonymousAuthor?: boolean;
+  footer?: JSX.Element;
+}): JSX.Element {
+  return (
+    <>
+      <SuggestionEmbed
+        description={
+          <>
+            <DiscordBold>Submitter</DiscordBold>
+            <br />
+            {anonymousAuthor ? 'Anonymous' : 'acollierr17'}
+            <br />
+            <br />
+            <DiscordBold>Suggestion</DiscordBold>
+            <br />
+            Bring out Wumpus to meet the fans!
+          </>
+        }
+        thumbnail={!anonymousAuthor}
+        color={EmbedColor.MAIN}
+        footer={
+          footer ? (
+            footer
+          ) : (
+            <>
+              {`Queued suggestion${
+                anonymousAuthor ? '' : ' | User ID: 158063324699951104'
+              }`}
+            </>
+          )
+        }
+        displayEmbedAuthor={false}
+        anonymousAuthor={anonymousAuthor}
+      />
+    </>
+  );
+}

--- a/src/components/Embeds/ServerConfiguration.tsx
+++ b/src/components/Embeds/ServerConfiguration.tsx
@@ -37,6 +37,16 @@ export default function ServerConfiguration(): JSX.Element {
             Anonymous resolutions: Suggesters are shown who resolved their
             suggestions.
             <br />
+            Using channel queue: This guild uses a channel based suggestions
+            queue.
+            <br />
+            Queue channel:{' '}
+            <DiscordMention type='channel'>suggestion-queue</DiscordMention>
+            <br />
+            Queue rejection channel:{' '}
+            <DiscordMention type='channel'>
+              suggestion-queue-logs
+            </DiscordMention>
           </span>
         </>
       }

--- a/src/components/Messages/QueuedSuggestionEmbedMessage.tsx
+++ b/src/components/Messages/QueuedSuggestionEmbedMessage.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import {
+  DiscordActionRow,
+  DiscordAttachments,
+  DiscordButton,
+} from '@skyra/discord-components-react';
+
+import QueuedSuggestion from '@site/src/components/Embeds/QueuedSuggestion';
+import SuggestionEmbedMessage from '@site/src/components/Messages/SuggestionEmbedMessage';
+import { SuggestionEmbedMessageProps } from '@site/src/constants';
+
+export default function QueuedSuggestionEmbedMessage(
+  options: SuggestionEmbedMessageProps,
+): JSX.Element {
+  return (
+    <>
+      <SuggestionEmbedMessage
+        embed={<QueuedSuggestion {...options.embed} />}
+        message={{
+          buttons: true,
+          buttonsOverride: (
+            <DiscordAttachments slot='components'>
+              <DiscordActionRow>
+                <DiscordButton type='success'>
+                  Approve queued suggestion
+                </DiscordButton>
+                <DiscordButton type='destructive'>
+                  Reject queued suggestion
+                </DiscordButton>
+              </DiscordActionRow>
+            </DiscordAttachments>
+          ),
+          ...options.message,
+        }}
+      />
+    </>
+  );
+}

--- a/src/components/Messages/SuggestionEmbedMessage.tsx
+++ b/src/components/Messages/SuggestionEmbedMessage.tsx
@@ -9,13 +9,8 @@ import {
   DiscordCommand,
 } from '@skyra/discord-components-react';
 
-import { EmbedProps, MessageProps } from '../../constants';
+import { SuggestionEmbedMessageProps } from '../../constants';
 import SuggestionEmbed from '../Embeds/SuggestionEmbed';
-
-type SuggestionEmbedMessageProps = {
-  message?: MessageProps;
-  embed?: EmbedProps | JSX.Element;
-};
 
 export default function SuggestionEmbedMessage(
   options: SuggestionEmbedMessageProps,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -58,6 +58,11 @@ export type MessageProps = {
   };
 };
 
+export type SuggestionEmbedMessageProps = {
+  message?: MessageProps;
+  embed?: EmbedProps | JSX.Element;
+};
+
 export type ErrorEmbedProps = {
   title: string;
   description: string | JSX.Element;

--- a/src/pages/changelog.md
+++ b/src/pages/changelog.md
@@ -13,21 +13,23 @@ Only changelogs newer than _December 4, 2023_, are documented.
 ## `March 10, 2024`
 
 ### Documented Changes
-- TBD
+- Ability to configure suggestions channel queue ([`acff1c1`](https://github.com/suggestionsbot/suggestions-bot/pull/75/commits/acff1c12711b4d16a932549a95d12d5c0724bfdc))
 
 ### Minor Changes
-- TBD
+- `pt_BR` translations ([`79a0be9`](https://github.com/suggestionsbot/suggestions-bot/pull/75/commits/79a0be99eaaea785b20ae0380adcd41b761b926f))
 
 ### Bug Fixes
-- TBD
+- Fix information disclosures in commands using the wrong value for the command author ([`5840093`](https://github.com/suggestionsbot/suggestions-bot/pull/75/commits/584009376f51621e524521ab8ef971a25de70698))
+- Fix images 404'ing after 2 weeks ([`d38a3c7`](https://github.com/suggestionsbot/suggestions-bot/pull/75/commits/d38a3c7a22cc91e77d4c827dd363a111e8f89e24))
 
 ### Technical Changes
 
 #### Documentation
-- TBD
+- No technical changes, but maybe upgrading to a v4 alpha version of [skyra-components](https://github.com/skyra-project/discord-components/blob/main/packages/core/UPGRADING-TO-V4.md) soon if a public release isn't available by then
 
 #### Bot
-- TBD
+- Moved to centralised logging ([`e083d20`](https://github.com/suggestionsbot/suggestions-bot/pull/75/commits/e083d20492d7c8c258f5d5664f029de1339cd794))
+- Added internal helper classes ([`cee879e`](https://github.com/suggestionsbot/suggestions-bot/pull/75/commits/cee879ebde7c7cb325e64095fa7a128f92f672f2))
 
 ## `January 4, 2024`
 

--- a/src/pages/changelog.md
+++ b/src/pages/changelog.md
@@ -10,6 +10,25 @@ Review previous changelogs in regard to newly added bot features and when they w
 Only changelogs newer than _December 4, 2023_, are documented.
 :::
 
+## `March 10, 2024`
+
+### Documented Changes
+- TBD
+
+### Minor Changes
+- TBD
+
+### Bug Fixes
+- TBD
+
+### Technical Changes
+
+#### Documentation
+- TBD
+
+#### Bot
+- TBD
+
 ## `January 4, 2024`
 
 ### Documented Changes


### PR DESCRIPTION
This PR addresses the new changes to v3.22 of the bot. The main feature of this bot update is the introduction of the suggestions channel queue, allowing server owners and administrators to manage queued suggestions more traditionally.

Additionally, the `pt_BR` translation was added, centralized logging was implemented, and some additional bug fixes were made.